### PR TITLE
Add Dockerfile to deploy in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:11
+
+WORKDIR /app
+
+EXPOSE 8080
+COPY . .
+RUN yarn install
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ General config file: `RDFExplorer/public/scripts/services/settings.js`
 
 To change the query execution behavior check: `RDFExplorer/public/scripts/services/property-graph.js`
 
+## Docker
+
+### Build
+
+```bash
+docker build -t rdfexplorer .
+```
+
+### Run
+
+```bash
+docker run --rm -it -p 8081:8080 rdfexplorer
+```
+
+> Access on http://localhost:8081/
+
 ## License
 
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.


### PR DESCRIPTION
Using node:11 (we could use a different version if required) and `yarn start`. 

Documentation to build and run the Docker container has been added to the README.md